### PR TITLE
Add column_names() to retrieve column names

### DIFF
--- a/lib/DBIx/Lite/ResultSet.pm
+++ b/lib/DBIx/Lite/ResultSet.pm
@@ -383,6 +383,18 @@ sub count {
     return $count;
 }
 
+sub column_names {
+    my $self = shift;
+
+    $self->{dbix_lite}->dbh_do(sub {
+        ($self->{sth}, my @bind) = $self->select_sth;
+        $self->{sth}->execute(@bind);
+    }) if !$self->{sth};
+
+    my $c = $self->{sth}->{NAME};
+    return wantarray ? @$c : $c;
+}
+
 sub get_column {
     my $self = shift;
     my $column_name = shift or croak "get_column() requires a column name";
@@ -646,6 +658,14 @@ The following syntax will always retrieve just the first row in an endless loop:
     while (my $book = $dbix->table('books')->next) {
         ...
     }
+
+=head2 column_names
+
+This method returns a list of column names.
+It returns array on list context and array reference on scalar context.
+
+    my @book_columns = $books_rs->column_names;
+    my $book_columns = $books_rs->column_names; # array reference
 
 =head2 get_column
 

--- a/t/sqlite.t
+++ b/t/sqlite.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
+use Test::More tests => 7;
 use DBIx::Lite;
 
 my $dbix = DBIx::Lite->new( abstract => { quote_char => '`', name_sep => '.' } );
@@ -34,6 +34,16 @@ $dbix->table('books')->insert({ id => 2, title => 'Camel Adventures', year => 20
 {
     my @titles = $dbix->table('books')->order_by('+title')->get_column('title');
     is_deeply \@titles, ['Camel Adventures', 'Camel Tales'], 'get_column';
+}
+
+{
+    my @expect = qw( id title year key );
+
+    my $column_names_ref = $dbix->table('books')->column_names;
+    is_deeply $column_names_ref, \@expect, 'column_names in scalar context';
+
+    my @column_names = $dbix->table('books')->column_names;
+    is_deeply \@column_names, \@expect, 'column_names in list context';
 }
 
 __END__


### PR DESCRIPTION
Sometimes column name is needed when generating csv header or ...
I don't know whether `column_names()` method name is proper or not.
Please change the method name if it is strange. :-)
