### PR TITLE
Fix for Table->resultset_class accessor

### DIFF
--- a/lib/DBIx/Lite/Schema/Table.pm
+++ b/lib/DBIx/Lite/Schema/Table.pm
@@ -89,7 +89,8 @@ sub resultset_class {
         $self->{resultset_class} = $class;
         return $self;
     }
-    
+
+    $class =  $self->{resultset_class};
     return undef if !$class;
     
     # make the custom class inherit from our base

--- a/t/custom_resultset.t
+++ b/t/custom_resultset.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use DBIx::Lite;
+my $dbix = DBIx::Lite->new();
+
+# define custom object classes
+$dbix->schema
+     ->table('subjects')
+     ->resultset_class('My::Subject::ResultSet');
+
+my $rs = $dbix->table('subjects');
+isa_ok($rs, 'My::Subject::ResultSet');
+can_ok($rs, 'some_custom_method');
+
+done_testing();
+
+package My::Subject::ResultSet;
+
+sub some_custom_method {}
+


### PR DESCRIPTION
Setting a custom `resultset_class` as in the synopsis did not work for me. I.e. `$dbix->table(...)` always returned a `DBIx::Lite::ResultSet`.
`DBIx::Lite->table` uses `DBIx::Lite::Table->resultset_class` to create the ResultSet object. However, `resultset_class` always returns `undef` when used as an accessor. 

I changed `Table->resultset_class` to return the `resultset_class` when used as an accessor but perhaps I am missing something...