### PR TITLE
Verify if DBIx::Connector connection is successful

### DIFF
--- a/lib/DBIx/Lite.pm
+++ b/lib/DBIx/Lite.pm
@@ -41,6 +41,7 @@ sub connect {
     
     $self->{connector} = DBIx::Connector->new(@_);
     $self->{dbh} = undef;
+    $self->dbh(1) or return undef;
     $self->dbh->{HandleError} = sub { croak $_[0] };
     
     $self;
@@ -71,8 +72,10 @@ sub dbh {
     my $self = shift;
     my ($dont_die) = @_;
     
-    return $self->{dbh} ? $self->{dbh}
+    my $dbh = $self->{dbh} ? $self->{dbh}
         : $self->{connector} ? $self->{connector}->dbh
+        : undef;
+    return $dbh ? $dbh
         : $dont_die ? undef
         : croak "No database handle or DBIx::Connector object provided";
 }


### PR DESCRIPTION
If `DBIx::Connector` connection fails (e.g. invalid password) `$self->{connector}->dbh` is undefined, which results in a fatal error inside `DBIx::Lite`. Make sure to verify the handle beforehand.