### PR TITLE
create a column alias for COUNT(*) so that optional SQL::Abstract::More column quoting works

### DIFF
--- a/lib/DBIx/Lite/ResultSet.pm
+++ b/lib/DBIx/Lite/ResultSet.pm
@@ -541,7 +541,9 @@ sub count {
     my $count;
     $self->{dbix_lite}->dbh_do(sub {
         # Postgres throws an error when using ORDER BY clauses with COUNT(*)
-        my $count_rs = $self->select(\ "COUNT(*)")->order_by(undef);
+        # create a column alias so that if SQL::Abstract::More quotes columns
+        # it'll quote the column "count" rather than the expression "COUNT(*)"
+        my $count_rs = $self->select( [\'COUNT(*)', 'count' ])->order_by(undef);
         my ($sth, @bind) = $count_rs->select_sth;
         $sth->execute(@bind);
         $count = +($sth->fetchrow_array)[0];

--- a/lib/DBIx/Lite/ResultSet.pm
+++ b/lib/DBIx/Lite/ResultSet.pm
@@ -543,7 +543,7 @@ sub count {
         # Postgres throws an error when using ORDER BY clauses with COUNT(*)
         # create a column alias so that if SQL::Abstract::More quotes columns
         # it'll quote the column "count" rather than the expression "COUNT(*)"
-        my $count_rs = $self->select( [\'COUNT(*)', 'count' ])->order_by(undef);
+        my $count_rs = $self->select( [\'COUNT(*)', 'dbix_lite_rs_count' ])->order_by(undef);
         my ($sth, @bind) = $count_rs->select_sth;
         $sth->execute(@bind);
         $count = +($sth->fetchrow_array)[0];


### PR DESCRIPTION

The existing code passes the expression COUNT(*) to SQL::Abstract::More, which intepreted it as a column name and if its quote_char option was set, quoted it, leading to errors such as

DBD::Pg::st execute failed: ERROR:  column "COUNT(*)" does not exist LINE 1: SELECT "COUNT(*)" FROM "temp0002" AS "me"
                ^ [for Statement "SELECT "COUNT(*)" FROM "temp0002" AS "me""]

This commit creates a column alias for COUNT(*), providing something appropriate for SQL::Abstract::More to quote.