### PR TITLE
bugfix: table alias failed for update & delete if SQLA's quote_char was set

### DIFF
--- a/lib/DBIx/Lite/ResultSet.pm
+++ b/lib/DBIx/Lite/ResultSet.pm
@@ -6,6 +6,7 @@ use Carp qw(croak);
 use Clone qw(clone);
 use Data::Page;
 use List::MoreUtils qw(uniq firstval);
+use version 0.77;
 use vars qw($AUTOLOAD);
 $Carp::Internal{$_}++ for __PACKAGE__;
 
@@ -464,8 +465,8 @@ sub delete_sql {
     }
     
     return $self->{dbix_lite}->{abstract}->delete(
-        $self->_table_alias_expr($self->{cur_table}{name}, 'delete'),
-        $delete_where,
+        -from => $self->_table_alias_expr($self->{cur_table}{name}, 'delete'),
+        -where => $delete_where,
     );
 }
 
@@ -644,13 +645,24 @@ sub _table_alias_expr {
     my ($table_name, $op) = @_;
     
     my $table_alias = $self->_table_alias($table_name, $op);
+
     if ($table_name eq $table_alias) {
         # foo
         return $table_name;
     } else {
-        # foo AS my_foo
-        return $self->{dbix_lite}->{abstract}->table_alias($table_name, $table_alias);
+
+        # As of SQL::Abstract::More v1.44, table alias syntax works for select, update, delete
+        my $supported_op = $op eq 'select' || $op eq 'update' || $op eq 'delete';
+        if ( $supported_op && version->parse(SQL::Abstract::More->VERSION) >= version->parse('1.44') ) {
+            return "$table_name|$table_alias";
+        }
+        else {
+            # foo AS my_foo
+            return $self->{dbix_lite}->{abstract}->table_alias($table_name, $table_alias);
+        }
+
     }
+
 }
 
 sub _inflate_row {


### PR DESCRIPTION
Prior to version 1.44 of `SQL::Abstract::More,` specifying a table alias as `"$table_name|$table_alias"` was supported only for `select,` not for `delete` or `update.`

`DBIx::Lite` worked around this by calling SQLA::M's `table_alias` method, which returns a string of

  "$table_name as $table_alias"

If SQLA's `quote_char` option is set, this entire construct is quoted, rather than just `$table_name,` leading to illegal SQL.

This commit will use the `"$name|$alias"` form if SQLA::M is version 1.44 or higher.

**Please Note**, this fix will not completely fix issues with quoting; there are [fixes to `SQL::Abstract::More`](https://github.com/damil/SQL-Abstract-More/pull/26) that need to be applied as well.  So far, this commit seems to be the only changed required to `DBIx::Lite`, but I haven't performed exhaustive testing.