### PR TITLE
backcompat: ensure that default select expression is created prior to calls to select_also()

### DIFF
--- a/lib/DBIx/Lite/ResultSet.pm
+++ b/lib/DBIx/Lite/ResultSet.pm
@@ -93,7 +93,7 @@ sub select {
 
 sub select_also {
     my $self = shift;
-    return $self->select(@{$self->{select} // []}, @_);
+    return $self->select(@{$self->{select} // [$self->{table_alias} . '.*']}, @_);
 }
 
 sub with {


### PR DESCRIPTION
A previous edit changed the initial state of the select expression list from a default value to undef.

In general, the code assumes that unless otherwise added to by the caller, an undef list indicates that the default select expression should be inserted.

However, select_also() assumes than an undef list means something else, and rather than creating a list with the default expression and then adding to it, it creates a list with just its contents.

Later on, after the call to select_also() the code which would have inserted the default expression interprets the non-undef value for the list as indication that the user has explicitly called select(), and thus doesn't add the default.

The end result is that calling select_also() without calling select() ends up with a final select expression without the default expression, which breaks with previous behavior.

The change in the value for the default expression came about during the addition of the table_alias attribute.

Prior to that the expression was initialized in the constructor to 'me.*'.

With the addition of the table_alias attribute, this is now [$self->{table_alias} . '.*'], and that is how it is set in later parts of the code which treat an undef select expression as equivalent to setting the default expression.

The initialization in the constructor was previsouly done prior to incorporating constructor arguments; presumably its removal was made under the assumption that later code would catch the undef list and insert the proper default expression using $self->{table_alias}.

This commit changes the assumptions of select_also() when faced with an undef expression list to match that of the rest of the code. All code which access $self->{select} now performs the same operation when presented an undef expression list.

This also resolves similar behavior that arises by calling select() without arguments, which sets the list to undef.  A subsequent call to select_also() would cause the same issue as is fixed here.